### PR TITLE
added support for tracing addTransceiver()

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ RTCPeerConnection methods are also hooked into and parameters sent to the server
 * addStream, removeStream
 * addTrack
 * removeTrack
+* addTransceiver
 * createOffer
 * createAnswer
 * setLocalDescription

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -389,8 +389,8 @@ export default function(
                         } else {
                             opts = `${trackOrKind.kind}:${trackOrKind.id}`;
                         }
-                        if (arguments.length === 2) {
-                            opts += ' ' + arguments[1];
+                        if (arguments.length === 2 && typeof arguments[1] === 'object') {
+                            opts += ' ' + JSON.stringify(arguments[1]);
                         }
 
                         sendStatsEntry( method, this.__rtcStatsId, opts);

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -376,6 +376,33 @@ export default function(
             }
         });
 
+        [ 'addTransceiver' ].forEach(method => {
+            const nativeMethod = OrigPeerConnection.prototype[method];
+
+            if (nativeMethod) {
+                OrigPeerConnection.prototype[method] = function() {
+                    try {
+                        const trackOrKind = arguments[0];
+                        let opts;
+                        if (typeof trackOrKind === 'string') {
+                            opts = trackOrKind;
+                        } else {
+                            opts = `${trackOrKind.kind}:${trackOrKind.id}`;
+                        }
+                        if (arguments.length === 2) {
+                            opts += ' ' + arguments[1];
+                        }
+
+                        sendStatsEntry( method, this.__rtcStatsId, opts);
+                    } catch (error) {
+                        console.error(`RTCStats ${method} bind failed: `, error);
+                    }
+
+                    return nativeMethod.apply(this, arguments);
+                };
+            }
+        });
+
         [ 'createOffer', 'createAnswer' ].forEach(method => {
             const nativeMethod = OrigPeerConnection.prototype[method];
 


### PR DESCRIPTION
Since lib-jitsi-meet utilizes addTransceiver() these days we should probably trace it in here as well to be safe.