### PR TITLE
fix handling of different ICE candidate types

### DIFF
--- a/obfuscator.js
+++ b/obfuscator.js
@@ -138,11 +138,12 @@ export default function(data) {
     case 'onicecandidate':
         if (data[2] && data[2].candidate) {
 
+            let jsonRepr = data[2];
 
-            const jsonRepr = data[2].toJSON();
-
+            if (jsonRepr.toJSON) {
+                jsonRepr = jsonRepr.toJSON();
+            }
             jsonRepr.candidate = obfuscateCandidate(jsonRepr.candidate);
-
             data[2] = jsonRepr;
         }
         break;

--- a/obfuscator.js
+++ b/obfuscator.js
@@ -138,11 +138,8 @@ export default function(data) {
     case 'onicecandidate':
         if (data[2] && data[2].candidate) {
 
-            let jsonRepr = data[2];
+            const jsonRepr = data[2];
 
-            if (jsonRepr.toJSON) {
-                jsonRepr = jsonRepr.toJSON();
-            }
             jsonRepr.candidate = obfuscateCandidate(jsonRepr.candidate);
             data[2] = jsonRepr;
         }

--- a/trace-ws.js
+++ b/trace-ws.js
@@ -72,6 +72,7 @@ export default function({ endpoint, meetingFqn, onCloseCallback, useLegacy, obfu
         if (obfuscate) {
             switch (data[0]) {
             case 'addIceCandidate':
+            case 'onicecandidate':
             case 'setLocalDescription':
             case 'setRemoteDescription':
                 // These functions need to original values to work with


### PR DESCRIPTION
As onicecandidate and addIceCandidate use different input formats exceptions were thrown for every time we try to record addIceCandidate. This PR converts both formats into the same internally assumed format.